### PR TITLE
Revert "get compile error when using this mrbgem if the project also …

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -12,5 +12,4 @@ MRuby::Build.new do |conf|
   conf.enable_test
 
   gem_config(conf)
-  conf.gem mgem: "mruby-mtest"
 end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -9,6 +9,6 @@ MRuby::Gem::Specification.new('mruby-fileutils-simple') do |spec|
   spec.add_dependency 'mruby-io',          mgem: 'mruby-io'
   spec.add_dependency 'mruby-process',     mgem: 'mruby-process'
   spec.add_dependency 'mruby-onig-regexp', mgem: 'mruby-onig-regexp'
-  spec.add_test_dependency 'mruby-mtest'#,  mgem: 'mruby-mtest'
+  spec.add_test_dependency 'mruby-mtest',  mgem: 'mruby-mtest'
   spec.add_test_dependency 'mruby-env',    mgem: 'mruby-env'
 end


### PR DESCRIPTION
…uses mruby-mtest"

This reverts commit fe36977d4bc1e198f255cd8a721124238b842489.
